### PR TITLE
Add the process to keep a fork syncronized

### DIFF
--- a/git_cheetsheet.md
+++ b/git_cheetsheet.md
@@ -45,12 +45,12 @@ $ git commit -c ORIG_HEAD                                   (5)
 ## Contributing
  
 ### Process to contribute and solve merge conflicts:
-1. Fork the repository          1. Fork the repository
-2. Make changes on a local branch       2. Make changes on a local branch
-3. pull Master to be up-to-date         3. pull Master to be up-to-date
-4. merge master into you branch         4. merge master into you branch
-5. push your branch         5. push your branch
-6. pull request to merge.       6. pull request to merge.
+1. Fork the repository
+2. Make changes on a local branch
+3. pull Master to be up-to-date
+4. merge master into you branch
+5. push your branch
+6. pull request to merge.
  
 ### Keep your forked repository up-to-date with the original
 1. `git fetch upstream`

--- a/git_cheetsheet.md
+++ b/git_cheetsheet.md
@@ -42,10 +42,19 @@ $ git commit -c ORIG_HEAD                                   (5)
 ```
 [Source](http://stackoverflow.com/questions/927358/how-do-you-undo-the-last-commit)
 
-## Process to contribute and solve merge conflicts:
-1. Fork the repository
-2. Make changes on a local branch
-3. pull Master to be up-to-date
-4. merge master into you branch
-5. push your branch
-6. pull request to merge.
+## Contributing
+ 
+### Process to contribute and solve merge conflicts:
+1. Fork the repository          1. Fork the repository
+2. Make changes on a local branch       2. Make changes on a local branch
+3. pull Master to be up-to-date         3. pull Master to be up-to-date
+4. merge master into you branch         4. merge master into you branch
+5. push your branch         5. push your branch
+6. pull request to merge.       6. pull request to merge.
+ 
+### Keep your forked repository up-to-date with the original
+1. `git fetch upstream`
+2. `git checkout master`
+3. `git merge upstream/master`
+ 
+[Source](https://help.github.com/articles/syncing-a-fork/)


### PR DESCRIPTION
He añadido a la chuleta de git los pasos a seguir para mantener tu repositorio en local de un fork sincronizado con el repositorio original